### PR TITLE
Adopt Tailwind's default sm/md breakpoints

### DIFF
--- a/app/components/commission/CreateLinks.tsx
+++ b/app/components/commission/CreateLinks.tsx
@@ -53,7 +53,7 @@ const selectMainLinks = (links: string[]): { type: string; url: string }[] => {
  * 功能与规则：
  * 1. 优先从 links 中选取主要链接（Twitter、Pixiv、Patreon等），最多取3个。
  *    如果有 designLink，则主要链接的数量限制为2个（因为需要给 designLink 预留一个名额）。
- * 2. 渲染时，第一个链接不加左边距，后续链接通过添加 `ml-3 md:ml-2` 来分隔。
+ * 2. 渲染时，第一个链接不加左边距，后续链接通过添加 `ml-2 md:ml-3` 来分隔。
  * 3. 如果没有任何链接匹配（mainLinks为空且无designLink），则返回 'N/A'。
  * 4. 设计链接（Design）如果存在，始终在最后显示，并同样根据是否为第一个显示的链接决定是否添加间距。
  */
@@ -69,9 +69,9 @@ export const createLinks = ({ links, designLink }: CreateLinksProps) => {
   const limitedMainLinks = mainLinks.slice(0, maxMainLinks)
 
   // 将主要链接映射为 React 元素。
-  // 如果是第一个链接，不加 ml- 类。否则在类名中添加 'ml-3 md:ml-2' 来分隔链接。
+  // 如果是第一个链接，不加 ml- 类。否则在类名中添加 'ml-2 md:ml-3' 来分隔链接。
   const mainLinkElements = limitedMainLinks.map((link, index) => {
-    const marginClass = index > 0 ? 'ml-3 md:ml-2' : ''
+    const marginClass = index > 0 ? 'ml-2 md:ml-3' : ''
     return (
       <span key={`${link.type}-${index}`} className={marginClass}>
         <Link href={link.url} className="underline-offset-2 select-none" target="_blank">
@@ -83,7 +83,7 @@ export const createLinks = ({ links, designLink }: CreateLinksProps) => {
 
   // 如果有 designLink，需要根据当前已有链接数量决定是否加间距
   const designLinkElement = hasDesign ? (
-    <span key="Design" className={mainLinkElements.length > 0 ? 'ml-3 md:ml-2' : ''}>
+    <span key="Design" className={mainLinkElements.length > 0 ? 'ml-2 md:ml-3' : ''}>
       <Link
         href={sanitizeUrl(designLink!)}
         className="underline-offset-2 select-none"

--- a/app/components/commission/IllustratorInfo.tsx
+++ b/app/components/commission/IllustratorInfo.tsx
@@ -30,10 +30,10 @@ const IllustratorInfo = ({ commission, characterName }: IllustratorInfoProps) =>
   const hasBoth = hasCreator && hasDescription
 
   return (
-    <div className="flex w-full flex-wrap items-center gap-y-2 font-mono text-sm text-gray-800 md:text-xs dark:text-gray-300">
+    <div className="flex w-full flex-wrap items-center gap-y-2 font-mono text-xs text-gray-800 md:text-sm dark:text-gray-300">
       {/* 左侧信息块：包含日期、创作者、描述 */}
       <div className="flex items-center">
-        <span className="mr-16 select-none md:mr-6">
+        <span className="mr-6 select-none md:mr-16">
           <Link href={linkId} className="text-gray-800 no-underline dark:text-gray-300!">
             <time>{formattedDate}</time>
           </Link>
@@ -51,7 +51,7 @@ const IllustratorInfo = ({ commission, characterName }: IllustratorInfoProps) =>
           {hasBoth && (
             <>
               {/* 使用分隔符，并通过 mx 来控制间距，不使用空格字符 */}
-              <span className="mx-4 select-none md:mx-2">|</span>
+              <span className="mx-2 select-none md:mx-4">|</span>
               <span>{description}</span>
             </>
           )}

--- a/app/components/commission/Listing.tsx
+++ b/app/components/commission/Listing.tsx
@@ -63,7 +63,7 @@ const Listing = ({ Character }: ListingProps) => {
                 />
               )}
               {/* 显示委托作品的详细信息 */}
-              <div className="mt-8 mb-4 md:mt-6 md:mb-2">
+              <div className="mt-6 mb-2 md:mt-8 md:mb-4">
                 <IllustratorInfo commission={commission} characterName={Character} />
               </div>
             </div>

--- a/app/components/main/CharacterList.tsx
+++ b/app/components/main/CharacterList.tsx
@@ -61,7 +61,7 @@ const CharacterList = () => {
   return (
     <aside
       id="Character List"
-      className="fixed top-52 left-[calc(50%+20rem)] h-screen w-full max-w-[15rem] md:hidden"
+      className="hidden md:fixed md:top-52 md:left-[calc(50%+20rem)] md:block md:h-screen md:w-full md:max-w-[15rem]"
     >
       <nav className="sticky top-4 ml-8">
         <ul className="space-y-2">

--- a/app/components/main/Description.tsx
+++ b/app/components/main/Description.tsx
@@ -6,7 +6,7 @@ import Title from '#components/Title'
 const CommissionDescription = () => {
   return (
     <div id="--------Description--------">
-      <h1 className="pb-2 md:pb-0">Commission Vault</h1>
+      <h1 className="pb-0 md:pb-2">Commission Vault</h1>
       <Title Content="Introduction" />
 
       <p className="pt-4">
@@ -18,13 +18,13 @@ const CommissionDescription = () => {
         </Link>
         .
       </p>
-      <p className="pt-6 md:pt-4">
+      <p className="pt-4 md:pt-6">
         I am not an illustrator but someone who frequently commissions artworks. If you appreciate
         the illustrations, please consider following and supporting the illustrators.
         <br />
         You may also consider to <Link href="/support">support my commission projects</Link>.
       </p>
-      <p className="pt-6 md:pt-4">
+      <p className="pt-4 md:pt-6">
         If any illustrators or readers wish to get in touch, don&apos;t hesitate to reach out
         through <Link href="https://odaibako.net/u/CrystallizeSub">odaibako</Link> or{' '}
         <Link href="mailto:contact@crystallize.cc">Email</Link>. Please note, any requests regarding

--- a/app/components/main/Footer.tsx
+++ b/app/components/main/Footer.tsx
@@ -21,7 +21,7 @@ const Footer = () => {
       </div>
 
       {/* The dates, name and DMCA */}
-      <small className="block pt-24 text-gray-800 md:pb-10 dark:text-gray-300">
+      <small className="block pt-24 pb-10 text-gray-800 md:pb-0 dark:text-gray-300">
         <time className="tracking-tight">2022 - {new Date().getFullYear()}</time> © Crystallize
         <div className="float-right">
           <Link

--- a/app/components/main/Hamburger.tsx
+++ b/app/components/main/Hamburger.tsx
@@ -273,7 +273,7 @@ MenuContent.displayName = 'MenuContent'
 // Hamburger 组件，用于显示汉堡菜单
 const Hamburger = () => {
   return (
-    <Menu as="div" className="fixed right-8 bottom-8 hidden md:block">
+    <Menu as="div" className="fixed right-8 bottom-8 md:hidden">
       {({ open, close }) => <MenuContent open={open} close={close} />}
     </Menu>
   )

--- a/app/components/main/Update.tsx
+++ b/app/components/main/Update.tsx
@@ -61,7 +61,7 @@ const Update = () => {
 
   // 渲染最新的委托作品信息
   return (
-    <div className="ss:text-xs mt-8 mb-4 flex flex-col font-mono text-sm md:mt-6 md:mb-4">
+    <div className="mt-6 mb-4 flex flex-col font-mono text-xs sm:text-sm md:mt-8">
       {/* 显示当前的委托总数 */}
       <p className="mb-2">Currently {totalCommissions} commissions</p>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -22,12 +22,12 @@
   /* Headings and Strong */
   h1 {
     margin-bottom: 0.4em;
-    @apply text-[1.6em] font-bold text-gray-800 md:text-[1.6em] dark:text-gray-100;
+    @apply text-[1.6em] font-bold text-gray-800 dark:text-gray-100;
   }
 
   h2 {
     font: bold;
-    @apply text-[1.5em] font-bold text-gray-800 md:text-[1.4em] dark:text-gray-100;
+    @apply text-[1.4em] font-bold text-gray-800 dark:text-gray-100 md:text-[1.5em];
   }
 
   /* Article Main Font color */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,7 +27,7 @@ export const metadata = SiteMeta
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={`${plexSans.variable} ${customMono.variable} font-sans`}>
-      <body className="ss:pb-16 ss:pt-7 ss:text-sm mx-auto min-h-screen max-w-2xl pt-20 pb-32 leading-relaxed antialiased selection:bg-gray-400/25 md:mx-4 md:min-h-dvh dark:bg-neutral-900">
+      <body className="mx-4 min-h-dvh max-w-2xl pt-7 pb-16 text-sm leading-relaxed antialiased selection:bg-gray-400/25 sm:pt-20 sm:pb-32 sm:text-base md:mx-auto md:min-h-screen dark:bg-neutral-900">
         {children}
       </body>
       <Analytics />

--- a/app/support/components/CryptoAddress.tsx
+++ b/app/support/components/CryptoAddress.tsx
@@ -18,17 +18,17 @@ const CryptoAddress = ({ currencyName, address }: CryptoAddressProps) => {
   return (
     <li>
       <b>{currencyName}</b> {' - '}
-      <span className="cursor-pointer font-mono md:hidden" onClick={copyToClipboard}>
+      <span className="hidden cursor-pointer font-mono md:inline" onClick={copyToClipboard}>
         {address}
       </span>
       <p
-        className="hidden cursor-pointer text-gray-600 md:inline dark:text-gray-200"
+        className="inline cursor-pointer text-gray-600 md:hidden dark:text-gray-200"
         onClick={copyToClipboard}
       >
         Click to copy
       </p>
       {showFeedback && (
-        <span className="animate-fade-in-out ml-2.5 font-mono text-sm font-bold text-green-600 md:text-xs">
+        <span className="animate-fade-in-out ml-2.5 font-mono text-xs font-bold text-green-600 md:text-sm">
           Copied!
         </span>
       )}

--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -6,28 +6,28 @@ import CryptoAddress from './components/CryptoAddress'
 const Support: NextPage = () => {
   return (
     <div className="mx-auto max-w-[40rem]">
-      <h1 className="pb-6 md:pb-4">Support me!</h1>
+      <h1 className="pb-4 md:pb-6">Support me!</h1>
 
       {/* ======= Text ======= */}
 
       <div>
-        <p className="pb-6 md:pb-4">
+        <p className="pb-4 md:pb-6">
           Please consider support me if you appreciated the works I commissioned!
         </p>
-        <p className="pb-6 md:pb-4">
+        <p className="pb-4 md:pb-6">
           Commissioning such high-quality artworks at this pace made the entire project quite
           time-consuming and extremely expensive. Currently I found myself spending around 20k - 40k
           JPY on these each month. Therefore, any financial assistance you can provide, even a few
           dollars, would be greatly appreciated.
         </p>
-        <p className="pb-6 md:pb-4">
+        <p className="pb-4 md:pb-6">
           I&apos;m also thinking of replacing my very, very old car so I will be saving money from
           2024.
         </p>
       </div>
 
       {/* ======= Crypto ======= */}
-      <h2 className="pb-6 text-lg md:pb-4 md:text-base">Crypto Currencies</h2>
+      <h2 className="pb-4 text-base md:pb-6 md:text-lg">Crypto Currencies</h2>
 
       <div className="">
         <CryptoAddress currencyName="USDT (TRC20)" address="TEHCVekfCn5FxLFayUHAVj6qGpQyRW6Usa" />
@@ -46,24 +46,24 @@ const Support: NextPage = () => {
           address="0x128e6E0BC4ad6d4979A6C94B860Bef4a851eF01e"
         />
 
-        <p className="pt-6 pb-6 md:hidden md:pb-4">
+        <p className="hidden md:block md:pt-6 md:pb-6">
           Please click on the addresses to copy to clipboard.
         </p>
       </div>
 
       {/* ======= Footer ======= */}
 
-      <div className="pt-4 md:pt-8" />
+      <div className="pt-8 md:pt-4" />
       <hr />
-      <div className="pb-6 md:pb-4" />
+      <div className="pb-4 md:pb-6" />
 
-      <p className="pt-4 pb-6 md:pb-4">Thank you!</p>
+      <p className="pt-4 pb-4 md:pb-6">Thank you!</p>
 
-      <p className="pb-6 md:pb-4">Please remember to follow and support the illustrators!</p>
+      <p className="pb-4 md:pb-6">Please remember to follow and support the illustrators!</p>
 
       <div className="pb-6" />
 
-      <Link href="/" className="pb-6 md:pb-4">
+      <Link href="/" className="pb-4 md:pb-6">
         Back to Home
       </Link>
     </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,12 +3,6 @@ import type { Config } from 'tailwindcss'
 const config: Config = {
   content: ['./app/**/*.{js,ts,jsx,tsx,mdx}'],
   // darkMode: 'class',
-  theme: {
-    screens: {
-      ss: { max: '30rem' },
-      md: { max: '70rem' },
-    },
-  },
   plugins: [],
 }
 


### PR DESCRIPTION
## Summary
- migrate responsive utilities from custom `max` screens to Tailwind's default `sm` and `md` breakpoints
- adjust layout, navigation, and support pages to match new mobile-first breakpoints
- refine heading styles to use `md` variant

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e40a0c364833183414d84a7a68992