### PR TITLE
refactor: create three-column layout

### DIFF
--- a/app/components/main/CharacterList.tsx
+++ b/app/components/main/CharacterList.tsx
@@ -87,9 +87,9 @@ const CharacterList = () => {
   return (
     <aside
       id="Character List"
-      className="hidden md:fixed md:top-52 md:left-[calc(50%+20rem)] md:block md:h-screen md:w-full md:max-w-[15rem]"
+      className="hidden md:col-start-3 md:block md:h-screen md:w-full md:max-w-[15rem]"
     >
-      <nav className="sticky top-4 ml-8">
+      <nav className="sticky top-52">
         <ul className="space-y-2">
           {characterItems.map(({ id, displayName }) => {
             const isActive = activeId === `title-${id}`

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,8 +16,8 @@ const Home: NextPage = () => {
   return (
     <>
       <Warning />
-      <div className="relative mx-auto flex justify-center">
-        <div id="Main Contents" className="w-full max-w-[40rem]">
+      <div className="mx-auto grid max-w-screen-xl grid-cols-1 gap-x-8 md:grid-cols-[1fr_40rem_15rem]">
+        <div id="Main Contents" className="w-full max-w-[40rem] md:col-start-2">
           <CommissionDescription />
           <Commission />
           <Footer />


### PR DESCRIPTION
## Summary
- adopt a three-column grid layout so the main content remains centered at 640px and CharacterList occupies the right column
- simplify CharacterList positioning using grid column and sticky top spacing
- streamline grid class definitions for cleaner markup

## Testing
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_688ee1415ae883318f4bcf2938d3a175